### PR TITLE
Feature/config file permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Tags: n/a
 
+Security notes:
+* Version 0.1.4 and earlier did not set restrictive permissions on the configuration file created by the `aeriscli config` command; this could allow other users on your system to read the contents of that file. Version 0.1.5 attempts to restrict the permissions of that file when running the `aeriscli config`. Users upgrading from 0.1.4 or earlier are encouraged to either run `aeriscli config` again or set the permissions of the configuration file appropriately.
+
 New features or changes:
 * updates methods to raise an exception if the HTTP status code indicates a failure
 * updates the names of some methods to more closely align with their function

--- a/aerisapisdk/cli.py
+++ b/aerisapisdk/cli.py
@@ -62,6 +62,7 @@ def default_from_context(default_name, default_value=' '):
 def mycli(ctx, verbose, config_file):
     ctx.obj['verbose'] = verbose
     print('context:\n' + str(ctx.invoked_subcommand))
+    print('all dat context: ' + str(ctx.obj))
     if load_config(ctx, config_file):
         aerisutils.vprint(verbose, 'Valid config for account ID: ' + ctx.obj['accountId'])
     elif ctx.invoked_subcommand not in ['config',
@@ -139,7 +140,8 @@ def _set_config_file_permissions(filename):
         # "The SYSTEM account's permissions can be removed from a file, but we do not recommend removing them."
         dacl_to_set.AddAccessAllowedAce(win32security.ACL_REVISION, con.FILE_ALL_ACCESS, system_user)
         # The current user is the only normal user that should have access:
-        dacl_to_set.AddAccessAllowedAce(win32security.ACL_REVISION, con.FILE_GENERIC_READ | con.FILE_GENERIC_WRITE, user)
+        dacl_to_set.AddAccessAllowedAce(win32security.ACL_REVISION,
+                                        con.FILE_GENERIC_READ | con.FILE_GENERIC_WRITE, user)
         security_descriptor.SetSecurityDescriptorDacl(1, dacl_to_set, 0)
         win32security.SetFileSecurity(filename, win32security.DACL_SECURITY_INFORMATION, security_descriptor)
     else:

--- a/aerisapisdk/cli.py
+++ b/aerisapisdk/cli.py
@@ -1,6 +1,8 @@
 import click
 import json
+import os
 import pathlib
+import stat
 import aerisapisdk.aeradminsdk as aeradminsdk
 import aerisapisdk.aertrafficsdk as aertrafficsdk
 import aerisapisdk.aerframesdk as aerframesdk
@@ -90,6 +92,7 @@ def config(ctx, accountid, apikey, email, deviceidtype, deviceid):
                      "primaryDeviceIdType": deviceidtype,
                      "primaryDeviceId": deviceid}
     with open(default_config_filename, 'w') as myconfigfile:
+        os.chmod(default_config_filename, stat.S_IRUSR | stat.S_IWUSR)
         json.dump(config_values, myconfigfile, indent=4)
 
 

--- a/aerisapisdk/cli.py
+++ b/aerisapisdk/cli.py
@@ -62,7 +62,6 @@ def default_from_context(default_name, default_value=' '):
 def mycli(ctx, verbose, config_file):
     ctx.obj['verbose'] = verbose
     print('context:\n' + str(ctx.invoked_subcommand))
-    print('all dat context: ' + str(ctx.obj))
     if load_config(ctx, config_file):
         aerisutils.vprint(verbose, 'Valid config for account ID: ' + ctx.obj['accountId'])
     elif ctx.invoked_subcommand not in ['config',

--- a/aerisapisdk/cli.py
+++ b/aerisapisdk/cli.py
@@ -104,8 +104,48 @@ def config(ctx, accountid, apikey, email, deviceidtype, deviceid):
                      "primaryDeviceIdType": deviceidtype,
                      "primaryDeviceId": deviceid}
     with open(default_config_filename, 'w') as myconfigfile:
-        os.chmod(default_config_filename, stat.S_IRUSR | stat.S_IWUSR)
+        try:
+            _set_config_file_permissions(default_config_filename)
+        except BaseException as e:
+            print(f'WARNING: Could not set permissions for file {default_config_filename}. Reason: {e}')
+            print('WARNING: You should ensure that the permissions of the file keep your API key secret.')
         json.dump(config_values, myconfigfile, indent=4)
+
+
+def _set_config_file_permissions(filename):
+    """
+    Sets the permissions of the configuration file such that only the current user can read or write the file.
+
+    Parameters
+    ----------
+    filename: str
+
+    Returns
+    -------
+    None
+    """
+    import platform
+    if platform.system() == 'Windows':
+        # hat tip to http://timgolden.me.uk/python/win32_how_do_i/add-security-to-a-file.html
+        import win32security
+        import win32api
+        import ntsecuritycon as con
+        user, domain, type = win32security.LookupAccountName("", win32api.GetUserName())
+        system_user, domain, type = win32security.LookupAccountName("", 'SYSTEM')
+        security_descriptor = win32security.GetFileSecurity(filename, win32security.DACL_SECURITY_INFORMATION)
+        dacl_to_set = win32security.ACL()
+        # ensure that SYSTEM still has full access --
+        # https://docs.microsoft.com/en-us/windows/security/identity-protection/access-control/local-accounts says
+        # "The SYSTEM account's permissions can be removed from a file, but we do not recommend removing them."
+        dacl_to_set.AddAccessAllowedAce(win32security.ACL_REVISION, con.FILE_ALL_ACCESS, system_user)
+        # The current user is the only normal user that should have access:
+        dacl_to_set.AddAccessAllowedAce(win32security.ACL_REVISION, con.FILE_GENERIC_READ | con.FILE_GENERIC_WRITE, user)
+        security_descriptor.SetSecurityDescriptorDacl(1, dacl_to_set, 0)
+        win32security.SetFileSecurity(filename, win32security.DACL_SECURITY_INFORMATION, security_descriptor)
+    else:
+        import os
+        import stat
+        os.chmod(filename, stat.S_IRUSR | stat.S_IWUSR)
 
 
 # ========================================================================

--- a/aerisapisdk/exceptions.py
+++ b/aerisapisdk/exceptions.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 class ApiException(Exception):
     """
     Represents an exception with an Aeris API, such as a device not being found or invalid authentication credentials.

--- a/poetry.lock
+++ b/poetry.lock
@@ -174,6 +174,15 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xm
 
 [[package]]
 category = "main"
+description = "Python for Window Extensions"
+marker = "sys_platform == \"win32\""
+name = "pywin32"
+optional = false
+python-versions = "*"
+version = "227"
+
+[[package]]
+category = "main"
 description = "Python HTTP for Humans."
 name = "requests"
 optional = false
@@ -248,7 +257,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "a0031a1fabf2ba8770a5d338de9369b576650db7673c04267136a508130c6881"
+content-hash = "5c8bd34293529eb6b22c9e8ec37a5153e6c8fd944c676db062e44b76037e60cf"
 python-versions = "^3.6.9"
 
 [metadata.files]
@@ -314,6 +323,20 @@ pyparsing = [
 pytest = [
     {file = "pytest-5.3.5-py3-none-any.whl", hash = "sha256:ff615c761e25eb25df19edddc0b970302d2a9091fbce0e7213298d85fb61fef6"},
     {file = "pytest-5.3.5.tar.gz", hash = "sha256:0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d"},
+]
+pywin32 = [
+    {file = "pywin32-227-cp27-cp27m-win32.whl", hash = "sha256:371fcc39416d736401f0274dd64c2302728c9e034808e37381b5e1b22be4a6b0"},
+    {file = "pywin32-227-cp27-cp27m-win_amd64.whl", hash = "sha256:4cdad3e84191194ea6d0dd1b1b9bdda574ff563177d2adf2b4efec2a244fa116"},
+    {file = "pywin32-227-cp35-cp35m-win32.whl", hash = "sha256:f4c5be1a293bae0076d93c88f37ee8da68136744588bc5e2be2f299a34ceb7aa"},
+    {file = "pywin32-227-cp35-cp35m-win_amd64.whl", hash = "sha256:a929a4af626e530383a579431b70e512e736e9588106715215bf685a3ea508d4"},
+    {file = "pywin32-227-cp36-cp36m-win32.whl", hash = "sha256:300a2db938e98c3e7e2093e4491439e62287d0d493fe07cce110db070b54c0be"},
+    {file = "pywin32-227-cp36-cp36m-win_amd64.whl", hash = "sha256:9b31e009564fb95db160f154e2aa195ed66bcc4c058ed72850d047141b36f3a2"},
+    {file = "pywin32-227-cp37-cp37m-win32.whl", hash = "sha256:47a3c7551376a865dd8d095a98deba954a98f326c6fe3c72d8726ca6e6b15507"},
+    {file = "pywin32-227-cp37-cp37m-win_amd64.whl", hash = "sha256:31f88a89139cb2adc40f8f0e65ee56a8c585f629974f9e07622ba80199057511"},
+    {file = "pywin32-227-cp38-cp38-win32.whl", hash = "sha256:7f18199fbf29ca99dff10e1f09451582ae9e372a892ff03a28528a24d55875bc"},
+    {file = "pywin32-227-cp38-cp38-win_amd64.whl", hash = "sha256:7c1ae32c489dc012930787f06244426f8356e129184a02c25aef163917ce158e"},
+    {file = "pywin32-227-cp39-cp39-win32.whl", hash = "sha256:c054c52ba46e7eb6b7d7dfae4dbd987a1bb48ee86debe3f245a2884ece46e295"},
+    {file = "pywin32-227-cp39-cp39-win_amd64.whl", hash = "sha256:f27cec5e7f588c3d1051651830ecc00294f90728d19c3bf6916e6dba93ea357c"},
 ]
 requests = [
     {file = "requests-2.23.0-py2.py3-none-any.whl", hash = "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ click = "^7.0"
 requests = "^2.22"
 pathlib = "^1.0.1"
 pycodestyle = "^2.5.0"
+pywin32 = {version = "^227", platform = "win32"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/sample/README.md
+++ b/sample/README.md
@@ -19,6 +19,6 @@ $ pip3 install aerisapisdk
 $ python3 aerframe_budget_geofence.py --help
 ```
 
-(Note: Windows users can use the `activate.bat` script instead of the `source` command: `venv\Scripts\activate.bat`)
+(Note: Windows users can run the `activate.bat` or `Activate.ps1` script instead of the `source` command. Those scripts are found inside `venv\Scripts\`)
 
 When you are done, you can deactivate the virtual environment by running the `deactivate` command.


### PR DESCRIPTION
As a note: re-running `aeriscli config` will clobber any changes to that file's permissions that a user may have made. 
(Silly example: if two users are on the same system, and user B depends on user A's configuration file (like, user A runs `aeriscli --config-file /home/usera/.aeris_config config && chmod 0666 /home/usera/.aeris_config`, and then user B runs `aeriscli --config-file /home/usera/.aeris_config <anycommand>`), this change will break that workflow if user A ever runs `aeriscli config` to change any values.)
I don't think that use case is very likely, so I'm OK with this known issue. 

Friends don't let friends share API keys.