### PR TITLE
Makes pycodestyle a dev-dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ This project used pycodestyle to ensure adherence to PEP 8 coding style rules.
 Running pycodestyle as below should return with no errors.
 
 ```
-$ pycodestyle --max-line-length=120 aerisapisdk/ tests/
+$ poetry run pycodestyle --max-line-length=120 aerisapisdk/ tests/
 ```
 
 ### Integration tests

--- a/poetry.lock
+++ b/poetry.lock
@@ -131,7 +131,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.8.1"
 
 [[package]]
-category = "main"
+category = "dev"
 description = "Python style guide checker"
 name = "pycodestyle"
 optional = false
@@ -248,7 +248,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "a0031a1fabf2ba8770a5d338de9369b576650db7673c04267136a508130c6881"
+content-hash = "73a86cb90107ceb6b4ff3f3d6e065684719002667879a98542e0f350f198f418"
 python-versions = "^3.6.9"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,11 @@ python = "^3.6.9"
 click = "^7.0"
 requests = "^2.22"
 pathlib = "^1.0.1"
-pycodestyle = "^2.5.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
 responses = "^0.10.11"
+pycodestyle = "^2.5.0"
 
 [tool.poetry.scripts]
 aeriscli = "aerisapisdk.cli:main"


### PR DESCRIPTION
Also notes in the README that you can run pycodestyle through `poetry run` --
no more needing a separate installation of pycodestyle.